### PR TITLE
Decouple Client HTML from Video Asset

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+
+<html>
+  <head>
+    <link rel="stylesheet" href="main.css">
+
+    <script src="//cdn.jsdelivr.net/npm/hls.js@latest"></script>
+    <script src="main.js"></script>
+  </head>
+
+  <body>
+    <video id="video" controls autoplay></video>
+  </body>
+</html>

--- a/client/main.css
+++ b/client/main.css
@@ -1,0 +1,13 @@
+body {
+  background-color : black;
+  margin : 0;
+}
+
+video {
+  left: 50%;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  max-height: 100%;
+}

--- a/client/main.js
+++ b/client/main.js
@@ -1,0 +1,104 @@
+/**
+ * Get the URI for the content that we want to play.
+ *
+ * This assumes that there is a url parameter with the key "video" that
+ * points to the name of the video we want to play. Will return |null| if
+ * it does not find the uri.
+ *
+ * Examples:
+ *  URL                                   | OUTPUT
+ *  --------------------------------------+--
+ *  index.html/?video=my-video.m3u8       | "my-video.m3u8
+ *  index.html/?video=my-other-video.m3u8 | "my-other-video.m3u8"
+ *  index.html/                           | null
+ *
+ * @param {string} url
+ * @return {?string}
+ */
+function getContentUri(url) {
+  // Get the params, if there are none, continu with an empty string.
+  var paramsToken = url.split('?')[1] || '';
+
+  // Get an array of x=y for each param.
+  var keyValueTokens = paramsToken.split('&');
+
+  // Break each token into a key and value string.
+  var keyValues = keyValueTokens.map(function(token) {
+    return token.split('=');
+  });
+
+  var videos = keyValues.filter(function(pair) {
+    return pair[0] == 'video';
+  });
+
+  // If |videos.length == 0|, then |videos[0]| will be |undefined|.
+  var foundPair = videos[0] || [];
+  return foundPair[1] || null;
+}
+
+/**
+ * Find the main video element on the page that we want to play
+ * video on. Will return |null| if the video element is not found.
+ *
+ * @return {HTMLMediaElement}
+ */
+function getVideoElement() {
+  var videoId = 'video';
+  var video = document.getElementById(videoId);
+
+  return /** @type {HTMLMediaElement} */ (video);
+}
+
+/**
+ * Play the content at |contentUri| on |videoElement| using the
+ * platform-provided method (src=).
+ *
+ * @param {!HTMLMediaElement} videoElement
+ * @param {string} contentUri
+ */
+function playUsingNativeSupport(videoElement, contentUri) {
+  videoElement.src = contentUri;
+  videoElemment.autoplay = true;
+}
+
+/**
+ * Play the content at |contentUri| on |videoElement| using the HLS JS library.
+ *
+ * @param {!HTMLMediaElement} videoElement
+ * @param {string} contentUri
+ */
+function playUsingHlsJS(videoElement, contentUri) {
+  var hls = new Hls();
+  hls.loadSource(contentUri);
+  hls.attachMedia(videoElement);
+  hls.on(Hls.Events.MANIFEST_PARSED, function() {
+    videoElement.play();
+  });
+}
+
+function main() {
+  // On iOS devices 'video.src=' supports playing HLS manifests, so we
+  // can use that directly.
+  var useNative = navigator.userAgent.match(/(iPhone|iPod|iPad)/i);
+
+  var contentUri = getContentUri(window.location.href);
+  var video = getVideoElement();
+
+  if (!video) {
+    console.log('Could not find video element.',
+                'Playback was aborted.');
+    return;
+  }
+
+  if (useNative) {
+    playUsingNativeSupport(video, contentUri);
+  } else if (Hls.isSupported()) {
+    playUsingHlsJS(video, contentUri);
+  } else {
+    console.log(
+        'Failed to start playback.',
+        'HLS playback is not supported on this platform.');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', main);

--- a/launch.sh
+++ b/launch.sh
@@ -382,54 +382,19 @@ ffmpeg \
 
 fi
 
-# Create a web page with embedded hls.js player.
-
-cat > /tmp/${vid}.html <<_PAGE_
-<!doctype html>
-<html>
-   <head></head>
-   <body>
-      <style>
-         body {
-         background-color : black;
-         margin : 0;
-         }
-         video {
-         left: 50%;
-         position: absolute;
-         top: 50%;
-         transform: translate(-50%, -50%);
-         width: 100%;
-         max-height: 100%;
-         }
-      </style>
-      <script src="//cdn.jsdelivr.net/npm/hls.js@latest"></script>
-      <video id="video" controls autoplay></video>
-      <script>
-         var video = document.getElementById('video');
-         if(navigator.userAgent.match(/(iPhone|iPod|iPad)/i)) {
-         video.src = '${vid}.m3u8';
-         video.autoplay = true;
-          }
-          else if(Hls.isSupported()) {
-            var hls = new Hls();
-            hls.loadSource('${vid}.m3u8');
-            hls.attachMedia(video);
-            hls.on(Hls.Events.MANIFEST_PARSED,function() {
-              video.play();
-          });
-         }
-      </script>
-   </body>
-</html>
-_PAGE_
-
-# Upload the player over HTTP PUT to the origin server
-
-curl -X PUT --upload-file /tmp/${vid}.html http://${1}/${vid}.html -H "Content-Type: text/html; charset=utf-8"
+# Copy our client code (that we need to host) or out hosting directory. Copy
+# all the dependencies first, then copy the html.
+#
+# TODO: Add infrastructure that will inline the css and js into the HTML so
+#       that there will only be one asset to request. As part of this we will
+#       want to transpile for better browser compatibility and minmize the js
+#       to limit banwidth demands.
+curl -X PUT --upload-file ./client/main.css http://${1}/main.css     -H "Content-Type: text/html; charset=utf-8"
+curl -X PUT --upload-file ./client/main.js http://${1}/main.js       -H "Content-Type: text/javascript; charset=utf-8"
+curl -X PUT --upload-file ./client/index.html http://${1}/index.html -H "Content-Type: text/css; charset=utf-8"
 
 echo ...and awaaaaayyyyy we go! 🚀🚀🚀🚀
 
 echo Input detected on ${device} as ${res} ${fps}
 
-echo Currently streaming to: https://${2}/${vid}.html
+echo Currently streaming to: https://${2}/index.html/?video=${vid}.m3u8


### PR DESCRIPTION
Before the client HTML was heavily coupled to the video asset that was being served. This required the HTML to be generated each time.

In this change, the JavaScript that starts playback has been changed to read the asset resource from the url params. This allows the same client code to be used regardless of asset.

As part of this decoupling, the HTML, CSS, and JavaScript have been broken-up and moved to a client directory. This was to help them be viewable in isolation.